### PR TITLE
Fix typos in TrendingRepositoriesListViewModel.swift

### DIFF
--- a/SkillsTest/SkillsTest/Presentation/TrendingRepositoriesFeature/TradingRepositoriesList/ViewModel/TrendingRepositoriesListViewModel.swift
+++ b/SkillsTest/SkillsTest/Presentation/TrendingRepositoriesFeature/TradingRepositoriesList/ViewModel/TrendingRepositoriesListViewModel.swift
@@ -55,14 +55,14 @@ final class DefaultTrendingRepositoriesListViewModel: TrendingRepositoriesListVi
         dataLoadTask = fetchTrendingRepositoriesUseCase.fetch(
             cached: { [weak self] page in
                 self?.mainQueue.async {
-                    self?.udpate(page.items)
+                    self?.update(page.items)
                 }
             },
             completion: { [weak self] result in
                 self?.mainQueue.async {
                     switch result {
                     case .success(let page):
-                        self?.udpate(page.items)
+                        self?.update(page.items)
                     case .failure(let error):
                         self?.handle(error: error)
                         self?.updateContent()
@@ -89,7 +89,7 @@ final class DefaultTrendingRepositoriesListViewModel: TrendingRepositoriesListVi
         }
     }
 
-    private func udpate(_ repositories: [Repository]) {
+    private func update(_ repositories: [Repository]) {
         items = repositories.map { TrendingRepositoriesListItemViewModel(repository: $0) }
         updateContent()
     }


### PR DESCRIPTION
Hi, I fixed several typos in TrendingRepositoriesListViewModel.swift (#Line: 58, 65, 92) 🫠
There was a typo in the function name I defined, so I fixed it.

- origin
  ```swift
  private func loadData() {
      ...
      self?.mainQueue.async {
          // #Line 58
          self?.udpate(page.items)
      }
      ...
      switch result {
      case .success(let page):
          // #Line 65
          self?.udpate(page.items)
  }
  
  // #Line 92
  private func udpate(_ repositories: [Repository]) { ...
  ```
- changed
  ```swift
  private func loadData() {
      ...
      self?.mainQueue.async {
          // #Line 58
          self?.update(page.items)
      }
      ...
      switch result {
      case .success(let page):
          // #Line 65
          self?.update(page.items)
  }
  
  // #Line 92
  private func update(_ repositories: [Repository]) { ...
  ```